### PR TITLE
Allow customers to optionally specifiy input artifact name

### DIFF
--- a/sam/app.yml
+++ b/sam/app.yml
@@ -21,6 +21,12 @@ Parameters:
     Type: String
     Description: Log level for Lambda function logging, e.g., ERROR, INFO, DEBUG, etc
     Default: INFO
+  InputArtifactName:
+    Type: String
+    Description: >-
+      Input artifact for SAR auto publish lambda action. Usually it is the build stage output artifact
+      containing packaged template
+    Default: BuildArtifact
   ArtifactStoreBucket:
     Type: String
     Description: The S3 bucket name that CodePipeline uses to store artifacts
@@ -38,6 +44,7 @@ Resources:
       Environment:
         Variables:
           LOG_LEVEL: !Ref LogLevel
+          INPUT_ARTIFACT: !Ref InputArtifactName
       Policies:
         - S3ReadPolicy:
             BucketName: !Ref ArtifactStoreBucket

--- a/src/s3helper.py
+++ b/src/s3helper.py
@@ -5,10 +5,10 @@ import lambdalogging
 import boto3
 import zipfile
 import io
+import os
+
 
 LOG = lambdalogging.getLogger(__name__)
-
-PACKAGED_TEMPLATE = 'BuildArtifact'
 
 
 def get_input_artifact(event):
@@ -57,11 +57,12 @@ def _find_artifact_in_list(input_artifacts):
         dict -- artifact to fetch from S3
 
     """
+    input_artifact_to_use = os.environ['INPUT_ARTIFACT']
     for artifact in input_artifacts:
-        if artifact['name'] == PACKAGED_TEMPLATE:
+        if artifact['name'] == input_artifact_to_use:
             return artifact
 
-    raise RuntimeError('Unable to find the artifact with name ' + PACKAGED_TEMPLATE)
+    raise RuntimeError('Unable to find the input artifact with name ' + input_artifact_to_use)
 
 
 def _unzip_as_string(data):

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -5,3 +5,5 @@ import os
 """Setup unit test environment."""
 my_path = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, my_path + '/../../src/')
+
+os.environ['INPUT_ARTIFACT'] = 'BuildArtifact'

--- a/test/unit/test_handler.py
+++ b/test/unit/test_handler.py
@@ -1,12 +1,12 @@
 """Unit test for handler.py."""
 import pytest
+import os
 
 from botocore.exceptions import ClientError
 from serverlessrepo.exceptions import S3PermissionsRequired
 
 import handler
 from test_constants import mock_codepipeline_event, mock_codepipeline_event_no_artifact_found
-from s3helper import PACKAGED_TEMPLATE
 
 
 @pytest.fixture
@@ -43,7 +43,7 @@ def test_publish(mock_s3helper, mock_codepipelinehelper, mock_serverlessrepo):
 
 
 def test_publish_unable_to_find_artifact(mock_s3helper, mock_codepipelinehelper, mock_serverlessrepo):
-    exception_thrown = RuntimeError('Unable to find the artifact with name ' + PACKAGED_TEMPLATE)
+    exception_thrown = RuntimeError('Unable to find the input artifact with name ' + os.environ['INPUT_ARTIFACT'])
     mock_s3helper.get_input_artifact.side_effect = exception_thrown
 
     handler.publish(mock_codepipeline_event_no_artifact_found, None)

--- a/test/unit/test_s3helper.py
+++ b/test/unit/test_s3helper.py
@@ -1,5 +1,6 @@
 """Unit test for handler.py."""
 import pytest
+import os
 from mock import MagicMock
 
 from botocore.exceptions import ClientError
@@ -43,7 +44,9 @@ def test_get_input_artifact_unable_to_find_artifact(mock_boto3, mock_zipfile):
     mock_s3 = MagicMock()
     mock_boto3.client.return_value = mock_s3
 
-    with pytest.raises(RuntimeError, match='Unable to find the artifact with name ' + s3helper.PACKAGED_TEMPLATE):
+    with pytest.raises(
+        RuntimeError, match='Unable to find the input artifact with name ' + os.environ['INPUT_ARTIFACT']
+    ):
         s3helper.get_input_artifact(mock_codepipeline_event_no_artifact_found)
 
     mock_s3.get_object.assert_not_called()


### PR DESCRIPTION
Allow customers to optionally specify input artifact name

*Issue #, if available:*
Currently the input artifact for the SAR auto publish lambda action is always `BuildArtifact`. We should make that as default and also let customers be able to use their own input artifact name.

*Description of changes:*
Allow customers to optionally specifiy input artifact name for the SAR auto publish lambda action.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
