### PR TITLE
fix: add GetApplication permission

### DIFF
--- a/sam/app.yml
+++ b/sam/app.yml
@@ -50,10 +50,15 @@ Resources:
                 - serverlessrepo:CreateApplication
                 - serverlessrepo:CreateApplicationVersion
                 - serverlessrepo:UpdateApplication
-                - serverlessrepo:GetApplication
               Resource:
                 !Sub 'arn:${AWS::Partition}:serverlessrepo:${AWS::Region}:${AWS::AccountId}:applications/*'
-
+        - Version: '2012-10-17'
+          Statement:
+            - Effect: 'Allow'
+              Action:
+                - serverlessrepo:GetApplication
+              Resource:
+                !Sub 'arn:${AWS::Partition}:serverlessrepo:*:*:applications/*'
 Outputs:
   ServerlessRepoPublishFunctionName:
     Description: Name of ServerlessRepoPublish lambda function

--- a/sam/app.yml
+++ b/sam/app.yml
@@ -13,8 +13,8 @@ Metadata:
     ReadmeUrl: ../../README.md
     Labels: [serverless, codepipeline, serverlessrepo]
     HomePageUrl: https://github.com/awslabs/aws-serverless-codepipeline-serverlessrepo-publish
-    SemanticVersion: 1.0.0
-    SourceCodeUrl: https://github.com/awslabs/aws-serverless-codepipeline-serverlessrepo-publish/tree/1.0.0
+    SemanticVersion: 1.0.1
+    SourceCodeUrl: https://github.com/awslabs/aws-serverless-codepipeline-serverlessrepo-publish/tree/1.0.1
 
 Parameters:
   LogLevel:
@@ -50,6 +50,7 @@ Resources:
                 - serverlessrepo:CreateApplication
                 - serverlessrepo:CreateApplicationVersion
                 - serverlessrepo:UpdateApplication
+                - serverlessrepo:GetApplication
               Resource:
                 !Sub 'arn:${AWS::Partition}:serverlessrepo:${AWS::Region}:${AWS::AccountId}:applications/*'
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
add GetApplication permission to Lambda role to support publish an application with nested application. Get the following error when trying to use the app to publish a SAR app with a nested application:
```
User: xxx is not authorized to perform: serverlessrepo:GetApplication on resource: <nested app arn>
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
